### PR TITLE
idiot-proofing: string copies instead of references

### DIFF
--- a/cost_map_core/include/cost_map_core/operators/inflation.hpp
+++ b/cost_map_core/include/cost_map_core/operators/inflation.hpp
@@ -83,8 +83,8 @@ public:
    * @param cost_map
    * @throw std::out_of_range if no map layer with name `layer` is present.
    */
-  void operator()(const std::string& layer_source,
-               const std::string& layer_destination,
+  void operator()(const std::string layer_source,
+               const std::string layer_destination,
                const float& inflation_radius,
                const InflationComputer& inflation_computer,
                CostMap& cost_map

--- a/cost_map_core/include/cost_map_core/operators/inflation.hpp
+++ b/cost_map_core/include/cost_map_core/operators/inflation.hpp
@@ -178,8 +178,8 @@ public:
    * @param cost_map
    * @throw std::out_of_range if no map layer with name `layer` is present.
    */
-  void operator()(const std::string& layer_source,
-                  const std::string& layer_destination,
+  void operator()(const std::string layer_source,
+                  const std::string layer_destination,
                   CostMap& cost_map
                  );
 

--- a/cost_map_core/src/lib/operators/inflation.cpp
+++ b/cost_map_core/src/lib/operators/inflation.cpp
@@ -18,8 +18,8 @@ namespace cost_map {
 ** Implementation
 *****************************************************************************/
 
-void Inflate::operator()(const std::string& layer_source,
-                         const std::string& layer_destination,
+void Inflate::operator()(const std::string layer_source,
+                         const std::string layer_destination,
                          const float& inflation_radius,
                          const InflationComputer& inflation_computer,
                          CostMap& cost_map

--- a/cost_map_core/src/lib/operators/inflation.cpp
+++ b/cost_map_core/src/lib/operators/inflation.cpp
@@ -182,8 +182,8 @@ Deflate::Deflate(const bool& do_not_strip_inscribed_region)
 {
 }
 
-void Deflate::operator()(const std::string& layer_source,
-                         const std::string& layer_destination,
+void Deflate::operator()(const std::string layer_source,
+                         const std::string layer_destination,
                          CostMap& cost_map
                          )
 {


### PR DESCRIPTION
When using the inflate operator the layers are adjust at the beginning

```
  const cost_map::Matrix& data_source = cost_map.get(layer_source);
  cost_map.add(layer_destination, data_source);
```

https://github.com/stonier/cost_map/blob/indigo-devel/cost_map_core/src/lib/operators/inflation.cpp#L32-L33

but later the layer reference is used to retrieve data

```
 enqueue(cost_map.get(layer_source), cost_map.get(layer_destination), i, j, i, j);
```

https://github.com/stonier/cost_map/blob/indigo-devel/cost_map_core/src/lib/operators/inflation.cpp#L51

At which point the string reference may point to an invalid memory address, since the `std::vector` freely shuffles memory around as needed, when adding or removing an item from the vector.

Passing string copies instead of references avoids this issue and adds only little overhead.
