### PR TITLE
[cost_map] adds special cases to improve costmap to occupancy grid conversion

### DIFF
--- a/cost_map/src/lib/converter.cpp
+++ b/cost_map/src/lib/converter.cpp
@@ -425,16 +425,28 @@ void toOccupancyGrid(const cost_map::CostMap& cost_map, const std::string& layer
 
   // Occupancy probabilities are in the range [0,100].  Unknown is -1.
   const float cellMin = 0;
-  const float cellMax = 100;
+  const float cellMax = 98;
   const float cellRange = cellMax - cellMin;
 
   const float data_minimum = 0;
-  const float data_maximum = 254;
-  for (CostMapIterator iterator(cost_map); !iterator.isPastEnd(); ++iterator) {
+  const float data_maximum = 252;
+  for (CostMapIterator iterator(cost_map); !iterator.isPastEnd(); ++iterator)
+  {
     float value;
-    if (cost_map.at(layer, *iterator) == cost_map::NO_INFORMATION) {
+    if (cost_map.at(layer, *iterator) == cost_map::NO_INFORMATION) // 255
+    {
       value = -1;
-    } else {
+    }
+    else if (cost_map.at(layer, *iterator) == cost_map::LETHAL_OBSTACLE) // 254
+    {
+      value = 100;
+    }
+    else if (cost_map.at(layer, *iterator) == cost_map::INSCRIBED_OBSTACLE) // 253
+    {
+      value = 99;
+    }
+    else
+    {
       value = (cost_map.at(layer, *iterator) - data_minimum) / (data_maximum - data_minimum);
       value = cellMin + std::min(std::max(0.0f, value), 1.0f) * cellRange;
     }


### PR DESCRIPTION
Due to the different ranges in the cost map (0 - 255) and occupancy grid (0 - 100) cell values there is no 1:1 mapping possible.

So far lethal and inscribed values have been mapped fine, but for example the value _inscribed - 1_ (252) is mapped to _inscribed_ (99).

The proposed change ensures correct mapping of the non-free cases and limits the approximation to the available range for free spaces.
