### PR TITLE
[cost_map_core] makes the isInside checks const

### DIFF
--- a/cost_map_core/include/cost_map_core/iterators/CircleIterator.hpp
+++ b/cost_map_core/include/cost_map_core/iterators/CircleIterator.hpp
@@ -69,7 +69,7 @@ private:
    * Check if current index is inside the circle.
    * @return true if inside, false otherwise.
    */
-  bool isInside();
+  bool isInside() const;
 
   /*!
    * Finds the submap that fully contains the circle and returns the parameters.

--- a/cost_map_core/include/cost_map_core/iterators/EllipseIterator.hpp
+++ b/cost_map_core/include/cost_map_core/iterators/EllipseIterator.hpp
@@ -71,7 +71,7 @@ private:
    * Check if current index is inside the ellipse.
    * @return true if inside, false otherwise.
    */
-  bool isInside();
+  bool isInside() const;
 
   /*!
    * Finds the submap that fully contains the ellipse and returns the parameters.

--- a/cost_map_core/include/cost_map_core/iterators/PolygonIterator.hpp
+++ b/cost_map_core/include/cost_map_core/iterators/PolygonIterator.hpp
@@ -68,7 +68,7 @@ private:
    * Check if current index is inside polygon.
    * @return true if inside, false otherwise.
    */
-  bool isInside();
+  bool isInside() const;
 
   /*!
    * Finds the submap that fully contains the polygon and returns the parameters.

--- a/cost_map_core/include/cost_map_core/iterators/SpiralIterator.hpp
+++ b/cost_map_core/include/cost_map_core/iterators/SpiralIterator.hpp
@@ -76,7 +76,7 @@ private:
    * Check if index is inside the circle.
    * @return true if inside, false otherwise.
    */
-  bool isInside(const Index index);
+  bool isInside(const Index index) const;
 
   /*!
    * Uses the current distance to get the points of a ring

--- a/cost_map_core/src/lib/iterators/circle_iterator.cpp
+++ b/cost_map_core/src/lib/iterators/circle_iterator.cpp
@@ -72,7 +72,7 @@ bool CircleIterator::isPastEnd() const
   return internalIterator_->isPastEnd();
 }
 
-bool CircleIterator::isInside()
+bool CircleIterator::isInside() const
 {
   Position position;
   grid_map::getPositionFromIndex(position, *(*internalIterator_), mapLength_, mapPosition_, resolution_, bufferSize_, bufferStartIndex_);

--- a/cost_map_core/src/lib/iterators/ellipse_iterator.cpp
+++ b/cost_map_core/src/lib/iterators/ellipse_iterator.cpp
@@ -76,7 +76,7 @@ bool EllipseIterator::isPastEnd() const
   return internalIterator_->isPastEnd();
 }
 
-bool EllipseIterator::isInside()
+bool EllipseIterator::isInside() const
 {
   Position position;
   grid_map::getPositionFromIndex(position, *(*internalIterator_), mapLength_, mapPosition_, resolution_, bufferSize_, bufferStartIndex_);

--- a/cost_map_core/src/lib/iterators/polygon_iterator.cpp
+++ b/cost_map_core/src/lib/iterators/polygon_iterator.cpp
@@ -68,7 +68,7 @@ bool PolygonIterator::isPastEnd() const
   return internalIterator_->isPastEnd();
 }
 
-bool PolygonIterator::isInside()
+bool PolygonIterator::isInside() const
 {
   Eigen::Vector2d position;
   grid_map::getPositionFromIndex(position, *(*internalIterator_), mapLength_, mapPosition_, resolution_, bufferSize_, bufferStartIndex_);

--- a/cost_map_core/src/lib/iterators/spiral_iterator.cpp
+++ b/cost_map_core/src/lib/iterators/spiral_iterator.cpp
@@ -70,7 +70,7 @@ bool SpiralIterator::isPastEnd() const
   return (distance_ == nRings_ && pointsRing_.empty());
 }
 
-bool SpiralIterator::isInside(const Index index)
+bool SpiralIterator::isInside(const Index index) const
 {
   Eigen::Vector2d position;
   grid_map::getPositionFromIndex(position, index, mapLength_, mapPosition_, resolution_, bufferSize_);


### PR DESCRIPTION
To make this check usable when working with const cost maps.

This goes along with a similar [PR in grid_map](https://github.com/yujinrobot/grid_map/pull/1).
