### PR TITLE
Correct geometry if ros costmap's getSizeInMeters is called

### DIFF
--- a/cost_map/include/cost_map/converter.hpp
+++ b/cost_map/include/cost_map/converter.hpp
@@ -103,13 +103,14 @@ grid_map::GridMap toGridMap(const cost_map::CostMap cost_map);
  * subwindow does not go off the edge of the underlying ros costmap!
  *
  * @param ros_costmap : a traditional ros costmap object (input).
- * @param geometry : size of the subwindow (metres x metres, 0x0 to get the whole costmap).
+ * @param geometry : size of the subwindow (mxm), use 0x0 to get the whole costmap.
  * @return shared pointer to the cost map object
  *
  * @note We should, but cannot use a const for the ros costmap since it hasn't been very
  * well designed. Treat it as such and do not change the internals inside.
  */
-CostMapPtr fromROSCostMap2D(costmap_2d::Costmap2DROS& ros_costmap, cost_map::Length& geometry);
+CostMapPtr fromROSCostMap2D(costmap_2d::Costmap2DROS& ros_costmap,
+                            const cost_map::Length& geometry=cost_map::Length::Zero());
 
 /**
  * @brief Copies all data from copied_cost_map to target_cost_map (have to be same size)

--- a/cost_map/src/applications/alignment_test.cpp
+++ b/cost_map/src/applications/alignment_test.cpp
@@ -53,12 +53,9 @@ void test(ros::NodeHandle& node_handle)
 
   Costmap2D* ros_cost_map = layers->getCostmap();
 
-  // this is the wierd one - it only covers size in cells * resolution - half a cell
-  cost_map::Length geometry(ros_cost_map->getSizeInMetersX(), ros_cost_map->getSizeInMetersY());
-//  double resolution = ros_cost_map->getResolution()
-//  cost_map::Length geometry(ros_cost_map->getSizeInCellsX()*resolution,
-//                            ros_cost_map->getSizeInCellsY()*resolution);
-  cost_map::CostMapPtr cost_map = cost_map::fromROSCostMap2D(map_ros, geometry);
+  cost_map::CostMapPtr cost_map = cost_map::fromROSCostMap2D(map_ros);
+//  cost_map::Length geometry(0,0);
+//  cost_map::CostMapPtr cost_map = cost_map::fromROSCostMap2D(map_ros, geometry);
 
   ros::Publisher pub = node_handle.advertise<nav_msgs::OccupancyGrid>("converted_back", 1, true);
   nav_msgs::OccupancyGrid occupancy_msg;

--- a/cost_map/src/applications/alignment_test.cpp
+++ b/cost_map/src/applications/alignment_test.cpp
@@ -53,7 +53,11 @@ void test(ros::NodeHandle& node_handle)
 
   Costmap2D* ros_cost_map = layers->getCostmap();
 
+  // this is the wierd one - it only covers size in cells * resolution - half a cell
   cost_map::Length geometry(ros_cost_map->getSizeInMetersX(), ros_cost_map->getSizeInMetersY());
+//  double resolution = ros_cost_map->getResolution()
+//  cost_map::Length geometry(ros_cost_map->getSizeInCellsX()*resolution,
+//                            ros_cost_map->getSizeInCellsY()*resolution);
   cost_map::CostMapPtr cost_map = cost_map::fromROSCostMap2D(map_ros, geometry);
 
   ros::Publisher pub = node_handle.advertise<nav_msgs::OccupancyGrid>("converted_back", 1, true);


### PR DESCRIPTION
Not sure if this *should* be done here. While it can help the user in
the face of surprise in the aforementioned function call, it will
create an error if they actually want this reduced size.

If fixes the problem with the test program though which does feed the function with that call.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stonier/cost_map/24)
<!-- Reviewable:end -->
