### PR TITLE
Fix subwindow copies from Costmap2DROS

### DIFF
--- a/cost_map_demos/include/cost_map_demos/utilities.hpp
+++ b/cost_map_demos/include/cost_map_demos/utilities.hpp
@@ -12,6 +12,7 @@
 ** Includes
 *****************************************************************************/
 
+#include <atomic>
 #include <costmap_2d/costmap_2d_ros.h>
 #include <iostream>
 #include <tf/transform_broadcaster.h>
@@ -33,16 +34,18 @@ namespace cost_map_demos {
  */
 class TransformBroadcaster {
 public:
-  TransformBroadcaster() {}
+  TransformBroadcaster() : shutdown_flag(false) {}
   virtual ~TransformBroadcaster();
   void add(const std::string& name, tf::Vector3 origin, const tf::Quaternion& orientation);
 
   void startBroadCastingThread();
   void broadcast();
+  void shutdown();
 
 private:
   std::map<std::string, tf::Transform> transforms;
   std::thread broadcasting_thread;
+  std::atomic<bool> shutdown_flag;
 };
 
 /*****************************************************************************

--- a/cost_map_demos/rviz/from_ros_costmaps.rviz
+++ b/cost_map_demos/rviz/from_ros_costmaps.rviz
@@ -4,7 +4,6 @@ Panels:
     Name: Displays
     Property Tree Widget:
       Expanded:
-        - /Status1
         - /TF1/Frames1
       Splitter Ratio: 0.715328
     Tree Height: 562
@@ -31,7 +30,7 @@ Visualization Manager:
   Class: ""
   Displays:
     - Alpha: 0.5
-      Cell Size: 1
+      Cell Size: 0.5
       Class: rviz/Grid
       Color: 160; 160; 164
       Enabled: true
@@ -57,6 +56,8 @@ Visualization Manager:
           Value: true
         base_link_5x5:
           Value: true
+        base_link_5x5_2_5x2_5_offset:
+          Value: true
         base_link_5x5_3x3_centre:
           Value: true
         base_link_5x5_3x3_offset:
@@ -74,13 +75,15 @@ Visualization Manager:
             {}
           base_link_5x5:
             {}
+          base_link_5x5_2_5x2_5_offset:
+            {}
           base_link_5x5_3x3_centre:
             {}
           base_link_5x5_3x3_offset:
             {}
       Update Interval: 0
       Value: true
-    - Alpha: 0.7
+    - Alpha: 1
       Class: rviz/Map
       Color Scheme: costmap
       Draw Behind: false
@@ -89,7 +92,7 @@ Visualization Manager:
       Topic: /converter/four_by_four/costmap
       Unreliable: false
       Value: true
-    - Alpha: 0.7
+    - Alpha: 1
       Class: rviz/Map
       Color Scheme: costmap
       Draw Behind: false
@@ -98,7 +101,7 @@ Visualization Manager:
       Topic: /converter/five_by_five/costmap
       Unreliable: false
       Value: true
-    - Alpha: 0.7
+    - Alpha: 1
       Class: rviz/Map
       Color Scheme: costmap
       Draw Behind: false
@@ -107,7 +110,7 @@ Visualization Manager:
       Topic: /converter/five_by_five_three_by_three_offset/costmap
       Unreliable: false
       Value: true
-    - Alpha: 0.7
+    - Alpha: 1
       Class: rviz/Map
       Color Scheme: costmap
       Draw Behind: false
@@ -116,7 +119,16 @@ Visualization Manager:
       Topic: /converter/five_by_five_three_by_three_centre/costmap
       Unreliable: false
       Value: true
-    - Alpha: 0.7
+    - Alpha: 1
+      Class: rviz/Map
+      Color Scheme: costmap
+      Draw Behind: false
+      Enabled: true
+      Name: ROS 5x5_2.5x2.5_offset
+      Topic: /converter/five_by_five_twohalf_by_twohalf_offset/costmap
+      Unreliable: false
+      Value: true
+    - Alpha: 1
       Class: rviz/Map
       Color Scheme: costmap
       Draw Behind: false
@@ -125,7 +137,7 @@ Visualization Manager:
       Topic: /converted_5x5
       Unreliable: false
       Value: false
-    - Alpha: 0.7
+    - Alpha: 1
       Class: rviz/Map
       Color Scheme: costmap
       Draw Behind: false
@@ -134,7 +146,7 @@ Visualization Manager:
       Topic: /converted_4x4
       Unreliable: false
       Value: false
-    - Alpha: 0.7
+    - Alpha: 1
       Class: rviz/Map
       Color Scheme: costmap
       Draw Behind: false
@@ -143,13 +155,22 @@ Visualization Manager:
       Topic: /converted_5x5_3x3_offset
       Unreliable: false
       Value: false
-    - Alpha: 0.7
+    - Alpha: 1
       Class: rviz/Map
       Color Scheme: costmap
       Draw Behind: false
       Enabled: false
       Name: Converted 5x5_3x3_centre
       Topic: /converted_5x5_3x3_centre
+      Unreliable: false
+      Value: false
+    - Alpha: 1
+      Class: rviz/Map
+      Color Scheme: costmap
+      Draw Behind: false
+      Enabled: false
+      Name: Converted 5x5_2.5x2.5_offset
+      Topic: /converted_5x5_2_5x2_5_offset
       Unreliable: false
       Value: false
   Enabled: true
@@ -175,23 +196,20 @@ Visualization Manager:
   Value: true
   Views:
     Current:
-      Class: rviz/Orbit
-      Distance: 21.5043
+      Angle: 0
+      Class: rviz/TopDownOrtho
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.06
         Stereo Focal Distance: 1
         Swap Stereo Eyes: false
         Value: false
-      Focal Point:
-        X: -0.222145
-        Y: 0.0297914
-        Z: 0.828205
       Name: Current View
       Near Clip Distance: 0.01
-      Pitch: 1.5698
+      Scale: 49.451
       Target Frame: <Fixed Frame>
-      Value: Orbit (rviz)
-      Yaw: 4.7054
+      Value: TopDownOrtho (rviz)
+      X: -2.81012
+      Y: -0.484576
     Saved: ~
 Window Geometry:
   Displays:
@@ -199,7 +217,7 @@ Window Geometry:
   Height: 846
   Hide Left Dock: false
   Hide Right Dock: false
-  QMainWindow State: 000000ff00000000fd00000004000000000000011e000002bdfc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000006901000005fb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c0061007900730100000033000002bd000000d801000005fb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f000002bdfc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a005600690065007700730100000033000002bd000000ab01000005fb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000004b00000003efc0100000002fb0000000800540069006d00650100000000000004b0000001f301000005fb0000000800540069006d006501000000000000045000000000000000000000027d000002bd00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  QMainWindow State: 000000ff00000000fd00000004000000000000013b000002bdfc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000006901000005fb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c0061007900730100000033000002bd000000d801000005fb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f000002bdfc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a005600690065007700730100000033000002bd000000ab01000005fb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e100000197000000030000062e0000003efc0100000002fb0000000800540069006d006501000000000000062e000001f301000005fb0000000800540069006d00650100000000000004500000000000000000000003de000002bd00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   Selection:
     collapsed: false
   Time:
@@ -208,6 +226,6 @@ Window Geometry:
     collapsed: false
   Views:
     collapsed: false
-  Width: 1200
-  X: 544
+  Width: 1582
+  X: 162
   Y: 51

--- a/cost_map_demos/src/applications/from_ros_costmaps.cpp
+++ b/cost_map_demos/src/applications/from_ros_costmaps.cpp
@@ -45,17 +45,20 @@ int main(int argc, char** argv)
   cost_map_demos::ROSCostmapServer ros_costmap_4x4("four_by_four", "base_link_4x4", cost_map::Position(0.0, -5.0), 4.0, 4.0);
   cost_map_demos::ROSCostmapServer ros_costmap_5x5_3x3_offset("five_by_five_three_by_three_offset", "base_link_5x5_3x3_offset", cost_map::Position(-6.0, 0.0), 5.0, 5.0);
   cost_map_demos::ROSCostmapServer ros_costmap_5x5_3x3_centre("five_by_five_three_by_three_centre", "base_link_5x5_3x3_centre", cost_map::Position(-6.0, -6.0), 5.0, 5.0);
+  cost_map_demos::ROSCostmapServer ros_costmap_5x5_2_5x2_5_offset("five_by_five_twohalf_by_twohalf_offset", "base_link_5x5_2_5x2_5_offset", cost_map::Position(-12.0, 0.0), 5.0, 5.0);
 
   /********************
   ** New Costmaps
   ********************/
   // MAKE SURE THIS STAY IN SYNC WITH src/tests/rostests/from_ros_costmaps/from_ros_costmaps.cpp!
-  cost_map::CostMap cost_map_5x5, cost_map_4x4, cost_map_5x5_3x3_offset, cost_map_5x5_3x3_centre;
+  cost_map::CostMap cost_map_5x5, cost_map_4x4, cost_map_5x5_3x3_offset, cost_map_5x5_3x3_centre, cost_map_5x5_2_5x2_5_offset;
   cost_map::fromCostMap2DROS(*(ros_costmap_5x5.getROSCostmap()), "obstacle_costs", cost_map_5x5);
   cost_map::fromCostMap2DROS(*(ros_costmap_4x4.getROSCostmap()), "obstacle_costs", cost_map_4x4);
   cost_map::Length geometry_3x3(3.0, 3.0);
   cost_map::fromCostMap2DROS(*(ros_costmap_5x5_3x3_offset.getROSCostmap()), geometry_3x3, "obstacle_costs", cost_map_5x5_3x3_offset);
   cost_map::fromCostMap2DROS(*(ros_costmap_5x5_3x3_centre.getROSCostmap()), geometry_3x3, "obstacle_costs", cost_map_5x5_3x3_centre);
+  cost_map::Length geometry_2_5x2_5(2.5, 2.5);
+  cost_map::fromCostMap2DROS(*(ros_costmap_5x5_2_5x2_5_offset.getROSCostmap()), geometry_2_5x2_5, "obstacle_costs", cost_map_5x5_2_5x2_5_offset);
 
   /********************
   ** Publishers
@@ -65,6 +68,7 @@ int main(int argc, char** argv)
   ros::Publisher pub_4x4 = node_handle.advertise<nav_msgs::OccupancyGrid>("converted_4x4", 1, true);
   ros::Publisher pub_5x5_3x3_offset = node_handle.advertise<nav_msgs::OccupancyGrid>("converted_5x5_3x3_offset", 1, true);
   ros::Publisher pub_5x5_3x3_centre = node_handle.advertise<nav_msgs::OccupancyGrid>("converted_5x5_3x3_centre", 1, true);
+  ros::Publisher pub_5x5_2_5x2_5_offset = node_handle.advertise<nav_msgs::OccupancyGrid>("converted_5x5_2_5x2_5_offset", 1, true);
 
   nav_msgs::OccupancyGrid occupancy_msg;
   cost_map::toOccupancyGrid(cost_map_5x5, cost_map_5x5.getLayers()[0], occupancy_msg);
@@ -75,6 +79,8 @@ int main(int argc, char** argv)
   pub_5x5_3x3_offset.publish(occupancy_msg);
   cost_map::toOccupancyGrid(cost_map_5x5_3x3_centre, cost_map_5x5_3x3_centre.getLayers()[0], occupancy_msg);
   pub_5x5_3x3_centre.publish(occupancy_msg);
+  cost_map::toOccupancyGrid(cost_map_5x5_2_5x2_5_offset, cost_map_5x5_2_5x2_5_offset.getLayers()[0], occupancy_msg);
+  pub_5x5_2_5x2_5_offset.publish(occupancy_msg);
 
   /********************
   ** Spin & Shutdown

--- a/cost_map_demos/src/lib/from_ros_costmaps.cpp
+++ b/cost_map_demos/src/lib/from_ros_costmaps.cpp
@@ -22,6 +22,7 @@ void broadcastCostmap2DROSTestSuiteTransforms(TransformBroadcaster& broadcaster)
   broadcaster.add("base_link_4x4", tf::Vector3(1.0, -3.0, 0.0), tf::Quaternion(0, 0, 0, 1));
   broadcaster.add("base_link_5x5_3x3_offset", tf::Vector3(-3.7, 2.4, 0.0), tf::Quaternion(0, 0, 0, 1));
   broadcaster.add("base_link_5x5_3x3_centre", tf::Vector3(-3.5, -3.5, 0.0), tf::Quaternion(0, 0, 0, 1));
+  broadcaster.add("base_link_5x5_2_5x2_5_offset", tf::Vector3(-9.7, 2.4, 0.0), tf::Quaternion(0, 0, 0, 1));
   broadcaster.startBroadCastingThread();
 }
 
@@ -48,7 +49,8 @@ ROSCostmapServer::ROSCostmapServer(const std::string& name,
   private_node_handle.setParam(name + "/origin_y", origin.y());
   private_node_handle.setParam(name + "/width", width);
   private_node_handle.setParam(name + "/height", height);
-  private_node_handle.setParam(name + "/resolution", 1.0);
+  private_node_handle.setParam(name + "/plugins", std::vector<std::string>());
+  private_node_handle.setParam(name + "/resolution", 0.5);
   private_node_handle.setParam(name + "/robot_radius", 0.03); // clears 1 cell if inside, up to 4 cells on a vertex
   costmap = std::make_shared<ROSCostmap>(name, transform_listener);
 

--- a/cost_map_demos/src/lib/utilities.cpp
+++ b/cost_map_demos/src/lib/utilities.cpp
@@ -44,6 +44,10 @@ TransformBroadcaster::~TransformBroadcaster() {
   broadcasting_thread.join();
 }
 
+void TransformBroadcaster::shutdown() {
+  shutdown_flag = true;
+}
+
 void TransformBroadcaster::add(const std::string& name, tf::Vector3 origin, const tf::Quaternion& orientation) {
   tf::Transform transform;
   transform.setOrigin(origin);
@@ -57,7 +61,7 @@ void TransformBroadcaster::startBroadCastingThread() {
 
 void TransformBroadcaster::broadcast() {
   tf::TransformBroadcaster tf_broadcaster;
-  while(ros::ok())
+  while(ros::ok() && !shutdown_flag )
   {
     for (std::pair<std::string, tf::Transform> p: transforms) {
       tf::StampedTransform stamped_transform(p.second, ros::Time::now(), "map", p.first);

--- a/cost_map_demos/src/test/rostests/from_ros_costmaps/from_ros_costmaps.cpp
+++ b/cost_map_demos/src/test/rostests/from_ros_costmaps/from_ros_costmaps.cpp
@@ -18,9 +18,9 @@
 
 TEST(CostMap2DROS, full_window) {
   std::cout << std::endl;
-  std::cout << "***********************************************************" << std::endl;
-  std::cout << "                 Copy Full Window" << std::endl;
-  std::cout << "***********************************************************" << std::endl;
+  ROS_INFO("***********************************************************");
+  ROS_INFO("                 Copy Full Window");
+  ROS_INFO("***********************************************************");
   // MAKE SURE THIS STAY IN SYNC WITH src/applications/from_ros_costmaps.cpp!
   // preparation
   std::string layer_name =  "obstacle_costs";
@@ -54,19 +54,43 @@ TEST(CostMap2DROS, full_window) {
 //    std::cout << std::endl;
 //  }
   // TODO a function which does the index conversion
-  ASSERT_EQ(cost_map_5x5.at(layer_name, cost_map::Index(1,4)), ros_costmap_5x5.getROSCostmap()->getCostmap()->getCost(3,0));
+  ASSERT_EQ(cost_map_5x5.at(layer_name, cost_map::Index(1,9)), ros_costmap_5x5.getROSCostmap()->getCostmap()->getCost(8,0));
   std::cout << std::endl;
 }
 
-TEST(CostMap2DROS, sub_window) {
+TEST(CostMap2DROS, cost_map_centres) {
   std::cout << std::endl;
-  std::cout << "***********************************************************" << std::endl;
-  std::cout << "                 Copy Sub Window" << std::endl;
-  std::cout << "***********************************************************" << std::endl;
-  cost_map::CostMap cost_map_5x5, cost_map_4x4;
+  ROS_INFO("***********************************************************");
+  ROS_INFO("                 Check Subwindow Centres");
+  ROS_INFO("***********************************************************");
+  ROS_INFO("Subwindows are centred as closely as possible to the robot");
+  ROS_INFO("pose, though not exactly. They still need to align with");
+  ROS_INFO("the underlying ros costmap so that they don't introduce a");
+  ROS_INFO("new kind of error. As a result, the centre is shifted from");
+  ROS_INFO("the robot pose to the nearest appropriate point which aligns");
+  ROS_INFO("the new cost map exactly on top of the original ros costmap.");
+  std::cout << std::endl;
+  std::string layer_name =  "obstacle_costs";
+  cost_map_demos::ROSCostmapServer ros_costmap_5x5_3x3_offset("five_by_five_three_by_three_offset", "base_link_5x5_3x3_offset", cost_map::Position(-6.0, 0.0), 5.0, 5.0);
+  cost_map_demos::ROSCostmapServer ros_costmap_5x5_3x3_centre("five_by_five_three_by_three_centre", "base_link_5x5_3x3_centre", cost_map::Position(-6.0, -6.0), 5.0, 5.0);
+  cost_map_demos::ROSCostmapServer ros_costmap_5x5_2_5x2_5_offset("five_by_five_twohalf_by_twohalf_offset", "base_link_5x5_2_5x2_5_offset", cost_map::Position(-12.0, 0.0), 5.0, 5.0);
+  cost_map::CostMap cost_map_5x5_3x3_offset, cost_map_5x5_3x3_centre, cost_map_5x5_2_5x2_5_offset;
+  cost_map::Length geometry_3x3(3.0, 3.0);
+  cost_map::fromCostMap2DROS(*(ros_costmap_5x5_3x3_offset.getROSCostmap()), geometry_3x3, layer_name, cost_map_5x5_3x3_offset);
+  cost_map::fromCostMap2DROS(*(ros_costmap_5x5_3x3_centre.getROSCostmap()), geometry_3x3, layer_name, cost_map_5x5_3x3_centre);
+  cost_map::Length geometry_2_5x2_5(2.5, 2.5);
+  cost_map::fromCostMap2DROS(*(ros_costmap_5x5_2_5x2_5_offset.getROSCostmap()), geometry_2_5x2_5, layer_name, cost_map_5x5_2_5x2_5_offset);
+  ROS_INFO_STREAM("  cost_map_5x5_3x3_offset : " << cost_map_5x5_3x3_offset.getPosition().transpose());
+  ROS_INFO_STREAM("  cost_map_5x5_3x3_offset : " << cost_map_5x5_3x3_centre.getPosition().transpose());
+  ROS_INFO_STREAM("  cost_map_5x5_3x3_offset : " << cost_map_5x5_2_5x2_5_offset.getPosition().transpose());
+  ASSERT_EQ(-3.5, cost_map_5x5_3x3_offset.getPosition().x());
+  ASSERT_EQ(2.5, cost_map_5x5_3x3_offset.getPosition().y());
+  ASSERT_EQ(-3.5, cost_map_5x5_3x3_centre.getPosition().x());
+  ASSERT_EQ(-3.5, cost_map_5x5_3x3_centre.getPosition().y());
+  ASSERT_EQ(-9.75, cost_map_5x5_2_5x2_5_offset.getPosition().x());
+  ASSERT_EQ(2.25, cost_map_5x5_2_5x2_5_offset.getPosition().y());
   std::cout << std::endl;
 }
-
 
 /*****************************************************************************
 ** Main program
@@ -80,7 +104,9 @@ int main(int argc, char **argv) {
   cost_map_demos::broadcastCostmap2DROSTestSuiteTransforms(broadcaster);
 
   testing::InitGoogleTest(&argc,argv);
-  return RUN_ALL_TESTS();
+  int result = RUN_ALL_TESTS();
+  broadcaster.shutdown();
+  return result;
 }
 
 


### PR DESCRIPTION
Had alignment problems previously. Now:

* Much simpler code
* Avoids the numeric inaccuracy problem (which was causing the bug)
* Adds a useful demo which visualises various permutations of usage
* Adds a test which tests various permutations of usage

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stonier/cost_map/38)
<!-- Reviewable:end -->
