### PR TITLE
Add custom node handle service provider constructor

### DIFF
--- a/cost_map_ros/include/cost_map_ros/converter.hpp
+++ b/cost_map_ros/include/cost_map_ros/converter.hpp
@@ -138,6 +138,8 @@ class Costmap2DROSServiceProvider {
 public:
   Costmap2DROSServiceProvider(costmap_2d::Costmap2DROS* ros_costmap,
                               const std::string& service_name="get_cost_map");
+  ROSCostMap2DServiceProvider(costmap_2d::Costmap2DROS* ros_costmap, ros::NodeHandle& node_handle,
+                              const std::string& service_name="get_cost_map");
 
   bool callback(cost_map_msgs::GetCostMap::Request  &req,
                 cost_map_msgs::GetCostMap::Response &res);

--- a/cost_map_ros/src/lib/converter.cpp
+++ b/cost_map_ros/src/lib/converter.cpp
@@ -304,7 +304,15 @@ Costmap2DROSServiceProvider::Costmap2DROSServiceProvider(costmap_2d::Costmap2DRO
   service = private_nodehandle.advertiseService(service_name, &Costmap2DROSServiceProvider::callback, this);
 }
 
-bool Costmap2DROSServiceProvider::callback(
+ROSCostMap2DServiceProvider::ROSCostMap2DServiceProvider(costmap_2d::Costmap2DROS* ros_costmap,
+                                                         ros::NodeHandle& node_handle,
+                                                         const std::string& service_name)
+: ros_costmap(ros_costmap)
+{
+  service = node_handle.advertiseService(service_name, &ROSCostMap2DServiceProvider::callback, this);
+}
+
+bool ROSCostMap2DServiceProvider::callback(
     cost_map_msgs::GetCostMap::Request  &request,
     cost_map_msgs::GetCostMap::Response &response)
 {


### PR DESCRIPTION
Allows supplying a node handle to the ROSCostMap2DServiceProvider.

Use case:

* Supply node handle with different callback queue which gets served by a separate thread by a AsyncSpinner